### PR TITLE
fix issue with fast scrolling not triggering event

### DIFF
--- a/lrInfiniteScroll.js
+++ b/lrInfiniteScroll.js
@@ -45,7 +45,7 @@
                     }
                     lastRemaining = remaining;
 
-                    if (remainingInverse && remainingInverse < lengthThreshold && (remainingInverse - lastRemainingInverse) < 0) {
+                    if (remainingInverse !== null && remainingInverse < lengthThreshold && (remainingInverse - lastRemainingInverse) < 0) {
                         //if there is already a timer running which has no expired yet we have to cancel it and restart the timer
                         if (promise !== null) {
                             $timeout.cancel(promise);


### PR DESCRIPTION
If I scroll smoothly and fast all the way to the top of my container, the event doesn't trigger.  It doesn't trigger because of the check that `remainingInverse` must be truthy, which fails when it is `0`.  I'm not sure if that is intentional behavior.  Checking for `null` explicitly solved the issue for me.  Thanks for implementing the inverse functionality, it was very useful for me.
